### PR TITLE
use params object to lookup SPLENV_REF

### DIFF
--- a/pipelines/stack_os_matrix.groovy
+++ b/pipelines/stack_os_matrix.groovy
@@ -34,7 +34,7 @@ notify.wrap {
 
   // override conda env ref from build_matrix.yaml
   if (SPLENV_REF) {
-    buildParams['LSST_SPLENV_REF'] = SPLENV_REF
+    buildParams['LSST_SPLENV_REF'] = params.SPLENV_REF
   }
 
   def lsstswConfigs = scipipe[BUILD_CONFIG]


### PR DESCRIPTION
As this will return null instead of a variable binding error when unset.