### PR TITLE
Removed documenteer from official release

### DIFF
--- a/pipelines/release/official_release.groovy
+++ b/pipelines/release/official_release.groovy
@@ -252,24 +252,6 @@ notify.wrap {
       } // retry
     }
 
-    triggerMe['doc build'] = {
-      retry(retries) {
-        build(
-          job: 'sqre/infra/documenteer',
-          parameters: [
-            string(name: 'EUPS_TAG', value: eupsTag),
-            string(name: 'LTD_SLUG', value: eupsTag),
-            string(name: 'RELEASE_IMAGE', value: stackResults.image),
-            booleanParam(
-              name: 'PUBLISH',
-              value: scipipe.release.step.documenteer.publish,
-            ),
-          ],
-          wait: false,
-        )
-      } // retry
-    }
-
     triggerMe['ap_verify'] = {
       retry(retries) {
         build(


### PR DESCRIPTION
Since the documenteer job needs to be run manually each time new content is added to the release, this call should be removed from the official release pipeline.