### PR TITLE
DM-22774: Store APDB in ap_verify Jenkins artifacts

### DIFF
--- a/pipelines/scipipe/ap_verify.groovy
+++ b/pipelines/scipipe/ap_verify.groovy
@@ -391,6 +391,7 @@ def void runApVerify(Map p) {
         util.record(util.xz([
           "${p.runDir}/**/*.log",
           "${p.runDir}/**/*.json",
+          "${p.runDir}/**/*.db",
         ]))
       }
     } // try


### PR DESCRIPTION
This PR adds a filter to `ap_verify.groovy` that should capture `association.db` (subject to any future renaming) and store it as a build artifact.