### PR TITLE
Change eups tag to "current".

### DIFF
--- a/pipelines/sqre/infra/documenteer.groovy
+++ b/pipelines/sqre/infra/documenteer.groovy
@@ -74,7 +74,7 @@ notify.wrap {
           docImage: meerImage,
           docTemplateDir: docTemplateDir,
           docPull: false,
-          eupsTag: eupsTag,
+          eupsTag: 'current',
         )
       } // stage
 


### PR DESCRIPTION
The correct version of the stack is selected by picking the appropriately-tagged Docker container based on the eups tag provided as a Jenkins pipeline parameter.  That container should only have one eups tag inside, in addition to "current".  We can therefore use "current" in the job.