### PR TITLE
DM-24036: Add SPLENV_REF parameter to run_rebuild and run_publish

### DIFF
--- a/jobs/build_publish.groovy
+++ b/jobs/build_publish.groovy
@@ -1,13 +1,17 @@
 import util.Plumber
+import org.yaml.snakeyaml.Yaml
+
+def scipipe = new Yaml().load(readFileFromWorkspace('etc/scipipe/build_matrix.yaml'))
 
 def p = new Plumber(name: 'release/build-publish', dsl: this)
 p.pipeline().with {
-  description('Run release/run-rebuild & release/rub-publish in series')
+  description('Run release/run-rebuild & release/run-publish in series')
 
   parameters {
     stringParam('REFS', null, 'Whitespace delimited list of "refs" to attempt to build.  Priority is highest -> lowest from left to right.  "master" is implicitly appended to the right side of the list, if not specified.')
     stringParam('PRODUCTS', null, 'Whitespace delimited list of EUPS products to build.')
     stringParam('EUPS_TAG', null, 'EUPS tag string. Note that EUPS does not deal well with "." or "-" as part of a tag')
     booleanParam('BUILD_DOCS', true, 'Build and publish documentation.')
+    stringParam('SPLENV_REF', scipipe.template.splenv_ref, 'conda env ref')
   }
 }

--- a/jobs/run_publish.groovy
+++ b/jobs/run_publish.groovy
@@ -1,4 +1,7 @@
 import util.Plumber
+import org.yaml.snakeyaml.Yaml
+
+def scipipe = new Yaml().load(readFileFromWorkspace('etc/scipipe/build_matrix.yaml'))
 
 // note that this job *will not work* unless run-rebuild has been executed at
 // least once in order to initialize the env.
@@ -12,6 +15,7 @@ p.pipeline().with {
     stringParam('EUPS_TAG', null, 'EUPS distrib tag name to publish. Eg. w_9999_52')
     stringParam('PRODUCTS', null, 'Whitespace delimited list of EUPS products to tag.')
     stringParam('TIMEOUT', '1', 'build timeout in hours')
+    stringParam('SPLENV_REF', scipipe.template.splenv_ref, 'conda env ref')
     // enable for debugging only
     // booleanParam('NO_PUSH', true, 'Skip s3 push.')
   }

--- a/jobs/run_rebuild.groovy
+++ b/jobs/run_rebuild.groovy
@@ -1,4 +1,7 @@
 import util.Plumber
+import org.yaml.snakeyaml.Yaml
+
+def scipipe = new Yaml().load(readFileFromWorkspace('etc/scipipe/build_matrix.yaml'))
 
 def p = new Plumber(name: 'release/run-rebuild', dsl: this)
 p.pipeline().with {
@@ -10,6 +13,7 @@ p.pipeline().with {
     booleanParam('BUILD_DOCS', false, 'Build and publish documentation.')
     booleanParam('PREP_ONLY', false, 'Pass -p flag to lsstsw/bin/rebuild -- prepare git clones/a manifest but do not build products.')
     stringParam('TIMEOUT', '8', 'build timeout in hours')
+    stringParam('SPLENV_REF', scipipe.template.splenv_ref, 'conda env ref')
     // enable for debugging only
     // booleanParam('NO_VERSIONDB_PUSH', true, 'Skip push to remote versiondb repo.')
   }

--- a/pipelines/lib/util.groovy
+++ b/pipelines/lib/util.groovy
@@ -278,6 +278,7 @@ def shJson(String script) {
  * @param p.parameters.EUPS_TAG String
  * @param p.parameters.PRODUCTS String
  * @param p.parameters.TIMEOUT String Defaults to `'1'`.
+ * @param p.parameters.SPLENV_REF String Optional
  */
 def void runPublish(Map p) {
   requireMapKeys(p, [
@@ -297,15 +298,22 @@ def void runPublish(Map p) {
     TIMEOUT: '1' // should be string
   ] + p.parameters
 
+  def jobParameters = [
+          string(name: 'EUPSPKG_SOURCE', value: useP.parameters.EUPSPKG_SOURCE),
+          string(name: 'MANIFEST_ID', value: useP.parameters.MANIFEST_ID),
+          string(name: 'EUPS_TAG', value: useP.parameters.EUPS_TAG),
+          string(name: 'PRODUCTS', value: useP.parameters.PRODUCTS),
+          string(name: 'TIMEOUT', value: useP.parameters.TIMEOUT.toString()),
+  ]
+
+  // Optional parameter. Set 'em if you got 'em
+  if (useP.parameters.SPLENV_REF) {
+    jobParameters += string(name: 'SPLENV_REF', value: useP.parameters.SPLENV_REF)
+  }
+
   build(
     job: useP.job,
-    parameters: [
-      string(name: 'EUPSPKG_SOURCE', value: useP.parameters.EUPSPKG_SOURCE),
-      string(name: 'MANIFEST_ID', value: useP.parameters.MANIFEST_ID),
-      string(name: 'EUPS_TAG', value: useP.parameters.EUPS_TAG),
-      string(name: 'PRODUCTS', value: useP.parameters.PRODUCTS),
-      string(name: 'TIMEOUT', value: useP.parameters.TIMEOUT.toString()),
-    ],
+    parameters: jobParameters,
   )
 } // runPublish
 
@@ -1295,6 +1303,7 @@ def ltdPush(Map p) {
  * @param p.parameters.BUILD_DOCS Boolean Defaults to `false`.
  * @param p.parameters.TIMEOUT String Defaults to `'8'`.
  * @param p.parameters.PREP_ONLY Boolean Defaults to `false`.
+ * @param p.parameters.SPLENV_REF String Optional
  * @return manifestId String
  */
 def String runRebuild(Map p) {
@@ -1310,15 +1319,22 @@ def String runRebuild(Map p) {
     PREP_ONLY: false,
   ] + p.parameters
 
+  def jobParameters = [
+          string(name: 'REFS', value: useP.parameters.REFS),
+          string(name: 'PRODUCTS', value: useP.parameters.PRODUCTS),
+          booleanParam(name: 'BUILD_DOCS', value: useP.parameters.BUILD_DOCS),
+          string(name: 'TIMEOUT', value: useP.parameters.TIMEOUT), // hours
+          booleanParam(name: 'PREP_ONLY', value: useP.parameters.PREP_ONLY),
+  ]
+
+  // Optional parameter. Set 'em if you got 'em
+  if (useP.parameters.SPLENV_REF) {
+    jobParameters += string(name: 'SPLENV_REF', value: useP.parameters.SPLENV_REF)
+  }
+
   def result = build(
     job: useP.job,
-    parameters: [
-      string(name: 'REFS', value: useP.parameters.REFS),
-      string(name: 'PRODUCTS', value: useP.parameters.PRODUCTS),
-      booleanParam(name: 'BUILD_DOCS', value: useP.parameters.BUILD_DOCS),
-      string(name: 'TIMEOUT', value: useP.parameters.TIMEOUT), // hours
-      booleanParam(name: 'PREP_ONLY', value: useP.parameters.PREP_ONLY),
-    ],
+    parameters: jobParameters,
     wait: true,
   )
 

--- a/pipelines/release/build_publish.groovy
+++ b/pipelines/release/build_publish.groovy
@@ -27,10 +27,16 @@ notify.wrap {
   String products   = params.PRODUCTS
   Boolean buildDocs = params.BUILD_DOCS
 
+  def splenvRef = lsstswConfig.splenv_ref
+  if (params.SPLENV_REF) {
+    splenvRef = params.SPLENV_REF
+  }
+
   echo "refs: ${refs}"
   echo "[eups] tag: ${eupsTag}"
   echo "products: ${products}"
   echo "build docs: ${buildDocs}"
+  echo "scipipe_conda_env ref: ${splenvRef}"
 
   def retries = 3
 
@@ -44,6 +50,7 @@ notify.wrap {
             REFS: refs,
             PRODUCTS: products,
             BUILD_DOCS: buildDocs,
+            SPLENV_REF: splenvRef,
           ],
         )
       } // retry
@@ -57,6 +64,7 @@ notify.wrap {
             MANIFEST_ID: manifestId,
             EUPS_TAG: eupsTag,
             PRODUCTS: products,
+            SPLENV_REF: splenvRef,
           ],
         )
       }

--- a/pipelines/release/run_publish.groovy
+++ b/pipelines/release/run_publish.groovy
@@ -35,6 +35,11 @@ notify.wrap {
   def canonical    = scipipe.canonical
   def lsstswConfig = canonical.lsstsw_config
 
+  def splenvRef = lsstswConfig.splenv_ref
+  if (params.SPLENV_REF) {
+    splenvRef = params.SPLENV_REF
+  }
+
   def slug = util.lsstswConfigSlug(lsstswConfig)
 
   def run = {
@@ -61,7 +66,7 @@ notify.wrap {
           "EUPS_PKGROOT=${pkgroot}",
           "EUPS_USERDATA=${cwd}/home/.eups_userdata",
           "EUPSPKG_SOURCE=${eupspkgSource}",
-          "LSST_SPLENV_REF=${lsstswConfig.splenv_ref}",
+          "LSST_SPLENV_REF=${splenvRef}",
           "MANIFEST_ID=${manifestId}",
           "EUPS_TAG=${eupsTag}",
           "PRODUCTS=${products}",

--- a/pipelines/release/run_rebuild.groovy
+++ b/pipelines/release/run_rebuild.groovy
@@ -43,6 +43,11 @@ notify.wrap {
   def canonical    = scipipe.canonical
   def lsstswConfig = canonical.lsstsw_config
 
+  def splenvRef = lsstswConfig.splenv_ref
+  if (params.SPLENV_REF) {
+    splenvRef = params.SPLENV_REF
+  }
+
   def slug = util.lsstswConfigSlug(lsstswConfig)
 
   def run = {
@@ -58,7 +63,7 @@ notify.wrap {
         LSST_PREP_ONLY:      prepOnly,
         LSST_PRODUCTS:       products,
         LSST_PYTHON_VERSION: lsstswConfig.python,
-        LSST_SPLENV_REF:     lsstswConfig.splenv_ref,
+        LSST_SPLENV_REF:     splenvRef,
         LSST_REFS:           refs,
         VERSIONDB_PUSH:      versiondbPush,
         VERSIONDB_REPO:      versiondbRepo,


### PR DESCRIPTION
Add SPLENV_REF to run_rebuild, run_publish, and build_publish.
Make it optional, keep behavior the same for other jobs that rely on the util functons.