### PR TITLE
Hotfix for build_publish job

### DIFF
--- a/pipelines/release/build_publish.groovy
+++ b/pipelines/release/build_publish.groovy
@@ -27,6 +27,9 @@ notify.wrap {
   String products   = params.PRODUCTS
   Boolean buildDocs = params.BUILD_DOCS
 
+  def canonical    = scipipe.canonical
+  def lsstswConfig = canonical.lsstsw_config
+
   def splenvRef = lsstswConfig.splenv_ref
   if (params.SPLENV_REF) {
     splenvRef = params.SPLENV_REF


### PR DESCRIPTION
The build_publish job was missing some of the same setup code that run_publish and run_rebuild had.
This is a small fix for that.