### PR TITLE
DM-24438: Handle new REF job parameter.

### DIFF
--- a/etc/scipipe/ap_verify.yaml
+++ b/etc/scipipe/ap_verify.yaml
@@ -28,3 +28,5 @@ ap_verify:
         <<: *dataset_hits2015
       # squash may take 10+ mins per metric upload (x7-12)
       run_timelimit: 150
+    - code:
+        <<: *code_ap

--- a/jobs/ap_verify.groovy
+++ b/jobs/ap_verify.groovy
@@ -5,6 +5,7 @@ p.pipeline().with {
   description('Execute ap_verify.')
 
   parameters {
+    stringParam('REF', null, 'Git "ref" of ap_verify to attempt to build.  Default uses version in release docker image.')
     stringParam('DOCKER_IMAGE', null, 'Explicit name of release docker image including tag.')
     booleanParam('NO_PUSH', true, 'Do not push results to squash.')
     booleanParam('WIPEOUT', false, 'Completely wipe out workspace(s) before starting build.')


### PR DESCRIPTION
While `dispatchverify.py` now takes a list of git references, only one is needed for `ap_verify`.  Because of the way the code is structured, it is easier to always set the code configuration defaults and remove them if `REF` is not specified (and thus no build is required).