### PR TITLE
Changes to support conda compilers

### DIFF
--- a/etc/scipipe/build_matrix.yaml
+++ b/etc/scipipe/build_matrix.yaml
@@ -31,6 +31,18 @@ template:
       label: centos-7
       compiler: llvm-toolset-7
       python: '3'
+    - &el7-conda
+      <<: *platform_defaults
+      image: docker.io/lsstdm/scipipe-base:7
+      label: centos-7-conda
+      compiler: conda-system
+      python: '3'
+    - &el8-conda
+      <<: *platform_defaults
+      image: docker.io/lsstdm/scipipe-base:8
+      label: centos-8-conda
+      compiler: conda-system
+      python: '3'
     - &sierra-py3
       <<: *platform_defaults
       image: null
@@ -49,36 +61,48 @@ template:
       label: osx-10.14
       compiler: clang-1000.10.44.4
       python: '3'
+    - &high_sierra-conda
+      <<: *platform_defaults
+      image: null
+      label: osx-10.13
+      compiler: conda-system
+      python: '3'
+    - &mojave-conda
+      <<: *platform_defaults
+      image: null
+      label: osx-10.14
+      compiler: conda-system
+      python: '3'
 #
 # build environment/matrix configs
 #
 scipipe-lsstsw-matrix:
-  - <<: *el7-dts8-py3
+  - <<: *el7-conda
 #    allow_fail: true
-  - <<: *el6-dts8-py3
+  - <<: *el8-conda
 #    allow_fail: true
-  - <<: *high_sierra-py3
+  - <<: *high_sierra-conda
     # allow builds on sierra and mojave
     label: osx-10.13||osx-10.14
     display_name: osx
     display_compiler: clang
 scipipe-lsstsw-lsst_distrib:
-  - <<: *el7-dts8-py3
-  - <<: *el6-dts8-py3
-  - <<: *high_sierra-py3
-  - <<: *mojave-py3
+  - <<: *el7-conda
+  - <<: *el8-conda
+  - <<: *high_sierra-conda
+  - <<: *mojave-conda
 scipipe-lsstsw-ci_hsc:
-  - <<: *el7-dts8-py3
+  - <<: *el7-conda
 dax-lsstsw-matrix:
-  - <<: *el7-dts8-py3
-  - <<: *el7-py3-llvm
+  - <<: *el7-conda
+#  - <<: *el7-py3-llvm # compiler is overridden when using conda
 #
 # canonical build env -- Ie., release/{run-rebuild,run-publish}
 #
 canonical:
   products: &canonical_products lsst_distrib lsst_ci
   lsstsw_config:
-    <<: *el7-dts8-py3
+    <<: *el7-conda
     label: snowflake-0
     display_name: centos-7
   workspace: snowflake/release
@@ -94,15 +118,15 @@ tarball:
   products: lsst_distrib lsst_dm_stack_demo
   build_config:
     - <<: *tarball_defaults
-      <<: *el6-dts8-py3
-      platform: el6
+      <<: *el8-conda
+      platform: el8
       osfamily: redhat
     - <<: *tarball_defaults
-      <<: *el7-dts8-py3
+      <<: *el7-conda
       platform: el7
       osfamily: redhat
     - <<: *tarball_defaults
-      <<: *mojave-py3
+      <<: *mojave-conda
       platform: '10.9'
       osfamily: osx
       timelimit: 8

--- a/etc/scipipe/build_matrix.yaml
+++ b/etc/scipipe/build_matrix.yaml
@@ -5,7 +5,7 @@
 # provide yaml anchors internal to this file.
 #
 template:
-  splenv_ref: &splenv_ref '984c9f7'
+  splenv_ref: &splenv_ref 'ed862f4'
   tarball_defaults: &tarball_defaults
     miniver: &miniver '4.7.12'
     timelimit: 6

--- a/etc/scipipe/build_matrix.yaml
+++ b/etc/scipipe/build_matrix.yaml
@@ -5,7 +5,7 @@
 # provide yaml anchors internal to this file.
 #
 template:
-  splenv_ref: &splenv_ref 'ed862f4'
+  splenv_ref: &splenv_ref '2deae7a'
   tarball_defaults: &tarball_defaults
     miniver: &miniver '4.7.12'
     timelimit: 6

--- a/etc/sqre/config.yaml
+++ b/etc/sqre/config.yaml
@@ -58,13 +58,9 @@ wget:
     tag: latest
 squash:
   url: https://squash-restful-api.lsst.codes/
-layercake:
-  packer:
-    github_repo: lsst-sqre/packer-layercake
-    git_ref: master
-    dir: ''
+scipipe_base:
   docker_registry:
-    repo: lsstsqre/centos
+    repo: lsstdm/scipipe-base
 jenkins_swarm_client:
   dockerfile:
     github_repo: lsst-sqre/docker-jenkins-swarm-client

--- a/pipelines/sqre/infra/build_newinstall.groovy
+++ b/pipelines/sqre/infra/build_newinstall.groovy
@@ -33,8 +33,8 @@ notify.wrap {
   def dockerRepo    = dockerRegistry.repo
   def newinstallUrl = util.newinstallUrl()
 
-  def baseDockerRepo = sqre.layercake.docker_registry.repo
-  def baseDockerTag  = '7-stackbase-devtoolset-8'
+  def baseDockerRepo = sqre.scipipe_base.docker_registry.repo
+  def baseDockerTag  = '7'
   def baseImage      = "${baseDockerRepo}:${baseDockerTag}"
   def splenvRef      = scipipe.canonical.lsstsw_config.splenv_ref
 


### PR DESCRIPTION
This PR adds support for the `conda-sys` compiler, as well as new containers for the linux builds.

It also adds support for centos 8 build containers.

The new containers are built in the docker-scipipe repository.

These pull requests enable these changes:
lsst-dm/docker-scipipe#1
lsst-sqre/ci-scripts#69

lsst-sqre/ci-scripts#69 should be merged before this PR.