### PR TITLE
Update scipipe_conda_env hash to prepare for 20.0

### DIFF
--- a/etc/scipipe/build_matrix.yaml
+++ b/etc/scipipe/build_matrix.yaml
@@ -5,7 +5,7 @@
 # provide yaml anchors internal to this file.
 #
 template:
-  splenv_ref: &splenv_ref '2deae7a'
+  splenv_ref: &splenv_ref 'cf0ec7b'
   tarball_defaults: &tarball_defaults
     miniver: &miniver '4.7.12'
     timelimit: 6


### PR DESCRIPTION
Update to the latest master hash.