### PR TITLE
Remove the conda mirror from all jobs

### DIFF
--- a/pipelines/lib/util.groovy
+++ b/pipelines/lib/util.groovy
@@ -461,10 +461,8 @@ def void jenkinsWrapper(Map buildParams) {
     }
 
     // setup env vars to use a conda mirror
-    withCondaMirrorEnv {
-      withEnv(buildEnv) {
-        bash './ci-scripts/jenkins_wrapper.sh'
-      }
+    withEnv(buildEnv) {
+      bash './ci-scripts/jenkins_wrapper.sh'
     }
   } finally {
     withEnv(["WORKSPACE=${cwd}"]) {


### PR DESCRIPTION
The mirror is broken and jobs which need to install conda are failing, this removes the use of the mirror.