### PR TITLE
DM-24262: Run HSC AP processing in CI using Gen 3

### DIFF
--- a/etc/scipipe/ap_verify.yaml
+++ b/etc/scipipe/ap_verify.yaml
@@ -23,8 +23,7 @@ ap_verify:
   defaults:
     squash_push: true
     retries: 3
-    # squash may take 10+ mins per metric upload (x7-12)
-    run_timelimit: 150
+    run_timelimit: 60
   configs:
     - dataset:
         <<: *dataset_hits2015

--- a/etc/scipipe/ap_verify.yaml
+++ b/etc/scipipe/ap_verify.yaml
@@ -23,10 +23,10 @@ ap_verify:
   defaults:
     squash_push: true
     retries: 3
+    # squash may take 10+ mins per metric upload (x7-12)
+    run_timelimit: 150
   configs:
     - dataset:
         <<: *dataset_hits2015
-      # squash may take 10+ mins per metric upload (x7-12)
-      run_timelimit: 150
       code:
         <<: *code_ap

--- a/etc/scipipe/ap_verify.yaml
+++ b/etc/scipipe/ap_verify.yaml
@@ -13,6 +13,12 @@ template:
       github_repo: lsst/ap_verify_ci_hits2015
       git_ref: master
       clone_timelimit: 15
+    cosmos_pdr2: &dataset_cosmos_pdr2
+      display_name: cosmos_pdr2
+      name: CI-CosmosPDR2
+      github_repo: lsst/ap_verify_ci_cosmos_pdr2
+      git_ref: master
+      clone_timelimit: 15
   codes:
     ap_verify: &code_ap
       name: ap_verify
@@ -28,5 +34,15 @@ ap_verify:
     - dataset:
         <<: *dataset_hits2015
       gen: 2
+      code:
+        <<: *code_ap
+    - dataset:
+        <<: *dataset_cosmos_pdr2
+      gen: 2
+      code:
+        <<: *code_ap
+    - dataset:
+        <<: *dataset_cosmos_pdr2
+      gen: 3
       code:
         <<: *code_ap

--- a/etc/scipipe/ap_verify.yaml
+++ b/etc/scipipe/ap_verify.yaml
@@ -27,5 +27,6 @@ ap_verify:
   configs:
     - dataset:
         <<: *dataset_hits2015
+      gen: 2
       code:
         <<: *code_ap

--- a/pipelines/scipipe/ap_verify.groovy
+++ b/pipelines/scipipe/ap_verify.groovy
@@ -258,23 +258,33 @@ def void verifyDataset(Map p) {
 
       // push results to squash
       if (p.squashPush) {
-        def files = []
-        dir(runDir) {
-          files = findFiles(glob: '**/ap_verify.*.verify.json')
-        }
+        switch (conf.gen) {
+          case 2:
+            def files = []
+            dir(runDir) {
+              files = findFiles(glob: '**/ap_verify.*.verify.json')
+            }
 
-        def codeRef = buildCode ? code.git_ref : "master"
-        withEnv([
-          "refs=${codeRef}",
-        ]) {
-          files.each { f ->
-            util.runDispatchVerify(
-              runDir: runDir,
-              lsstswDir: fakeLsstswDir,
-              datasetName: ds.name,
-              resultFile: f,
-            )
-          }
+            def codeRef = buildCode ? code.git_ref : "master"
+            withEnv([
+              "refs=${codeRef}",
+            ]) {
+              files.each { f ->
+                util.runDispatchVerify(
+                  runDir: runDir,
+                  lsstswDir: fakeLsstswDir,
+                  datasetName: ds.name,
+                  resultFile: f,
+                )
+              }
+            }
+            break
+          case 3:
+            // TODO: implement after DM-21916
+            break
+          default:
+            currentBuild.result = 'UNSTABLE'
+            echo "SQuaSH upload not supported for Gen ${conf.gen} pipeline framework; skipping"
         }
       }
     } // insideDockerWrap

--- a/pipelines/scipipe/ap_verify.groovy
+++ b/pipelines/scipipe/ap_verify.groovy
@@ -428,7 +428,8 @@ def void runApVerify(Map p) {
       dir(p.archiveDir) {
         util.record(util.xz([
           "${p.runDir}/**/*.log",
-          "${p.runDir}/**/*.json",
+          "${p.runDir}/**/*.json",  # Gen 2
+          "${p.runDir}/**/metricvalue_*/**/*.yaml",  # Gen 3
           "${p.runDir}/**/*.db",
         ]))
       }

--- a/pipelines/scipipe/ap_verify.groovy
+++ b/pipelines/scipipe/ap_verify.groovy
@@ -126,7 +126,7 @@ def String displayName(Map m) {
 }
 
 /**
- * Prepare, execute, and record results of a validation_drp run.
+ * Prepare, execute, and record results of an ap_verify run.
  *
  * @param p Map
  * @param p.config Map Dataset configuration.
@@ -311,8 +311,8 @@ def void verifyDataset(Map p) {
  *
  * @param p Map
  * @param p.homemDir String path to $HOME -- where to put dotfiles
- * @param p.codeDir String path to validate_drp (code)
- * @param p,runSlug String short name to describe this drp run
+ * @param p.codeDir String path to ap_verify (code)
+ * @param p,runSlug String short name to describe this ap_verify run
  * @param p.ciDir String
  * @param p.lsstCompiler String
  * @param p.archiveDir String path from which to archive artifacts
@@ -411,7 +411,7 @@ def void runApVerify(Map p) {
     '''
   }
 
-  // run drp driver script
+  // run ap driver script
   withEnv([
     "RUN_DIR=${p.runDir}",
     "DATASET_NAME=${p.dataset.name}",

--- a/pipelines/scipipe/ap_verify.groovy
+++ b/pipelines/scipipe/ap_verify.groovy
@@ -250,6 +250,7 @@ def void verifyDataset(Map p) {
       runApVerify(
         runDir: runDir,
         dataset: ds,
+        gen: conf.gen,
         datasetDir: datasetDir,
         homeDir: homeDir,
         archiveDir: jobDir,
@@ -374,6 +375,7 @@ def void buildAp(Map p) {
  * @param p Map
  * @param p.runDir String runtime cwd
  * @param p.dataset String full name of the validation dataset
+ * @param p.gen Integer pipeline generation to run
  * @param p.datasetDir String path to validation dataset
  * @param p.homemDir String path to $HOME -- where to put dotfiles
  * @param p.archiveDir String path from which to archive artifacts
@@ -382,6 +384,7 @@ def void runApVerify(Map p) {
   util.requireMapKeys(p, [
     'runDir',
     'dataset',
+    'gen',
     'datasetDir',
     'homeDir',
     'archiveDir',
@@ -404,7 +407,7 @@ def void runApVerify(Map p) {
       setup -k -r .
 
       cd ${RUN_DIR}
-      run_ci_dataset.sh -d ${DATASET_NAME}
+      run_ci_dataset.sh -d ${DATASET_NAME} -g ${DATASET_GEN}
     '''
   }
 
@@ -412,6 +415,7 @@ def void runApVerify(Map p) {
   withEnv([
     "RUN_DIR=${p.runDir}",
     "DATASET_NAME=${p.dataset.name}",
+    "DATASET_GEN=${p.gen}",
     "DATASET_DIR=${p.datasetDir}",
     "HOME=${p.homeDir}",
     "CODE_DIR=${p.codeDir}",

--- a/pipelines/scipipe/ap_verify.groovy
+++ b/pipelines/scipipe/ap_verify.groovy
@@ -56,6 +56,16 @@ notify.wrap {
     // butler
     def runSlug = "${datasetSlug(conf)}^${codeSlug(conf)}"
 
+    // these configs are used to construct a shell command line; guard against code injection
+    if (!(conf.dataset.name ==~ /[\w-.:]+/)) {
+      error "Ill-formed dataset name ${conf.dataset.name}"
+    }
+    if (conf.gen) {
+      conf.gen = conf.gen as int
+    } else {
+      error "Missing gen keyword in ${runSlug}"
+    }
+
     matrix[runSlug] = {
       verifyDataset(
         config: conf,


### PR DESCRIPTION
This PR implements combined Gen 2 and Gen 3 support for `scipipe/ap_verify`, and also does some cleanup of the relevant code. It also adds pipeline configurations for processing our draft Cosmos dataset.

Must be merged after lsst/ap_verify#99.