### PR TITLE
Fix syntax error in ap_verify.groovy.

### DIFF
--- a/pipelines/scipipe/ap_verify.groovy
+++ b/pipelines/scipipe/ap_verify.groovy
@@ -428,8 +428,8 @@ def void runApVerify(Map p) {
       dir(p.archiveDir) {
         util.record(util.xz([
           "${p.runDir}/**/*.log",
-          "${p.runDir}/**/*.json",  # Gen 2
-          "${p.runDir}/**/metricvalue_*/**/*.yaml",  # Gen 3
+          "${p.runDir}/**/*.json",  // Gen 2
+          "${p.runDir}/**/metricvalue_*/**/*.yaml",  // Gen 3
           "${p.runDir}/**/*.db",
         ]))
       }


### PR DESCRIPTION
This PR is a hotfix for a syntax error in #691 that broke `scipipe/ap_verify`.