### PR TITLE
Add the dustmaps package to the build environment

### DIFF
--- a/pipelines/sqre/validate_drp_gen3.groovy
+++ b/pipelines/sqre/validate_drp_gen3.groovy
@@ -308,6 +308,8 @@ def void buildDrpGen3(Map p) {
   def run = {
     util.bash '''
       set +o xtrace
+      pip install --user dustmaps
+      python -c "import dustmaps.sfd;dustmaps.sfd.fetch()"
 
       source "${CI_DIR}/ccutils.sh"
       cc::setup_first "$LSST_COMPILER"

--- a/pipelines/sqre/validate_drp_gen3.groovy
+++ b/pipelines/sqre/validate_drp_gen3.groovy
@@ -308,14 +308,15 @@ def void buildDrpGen3(Map p) {
   def run = {
     util.bash '''
       set +o xtrace
-      pip install --user dustmaps
-      python -c "import dustmaps.sfd;dustmaps.sfd.fetch()"
 
       source "${CI_DIR}/ccutils.sh"
       cc::setup_first "$LSST_COMPILER"
 
       source /opt/lsst/software/stack/loadLSST.bash
       setup -k -r .
+      
+      pip install --user dustmaps
+      python -c "import dustmaps.sfd;dustmaps.sfd.fetch()"
 
       set -o xtrace
 


### PR DESCRIPTION
We don't have `dustmaps` as part of the distributed system yet, but `metric-pipeline-tasks` depends on it.  This adds that package and downloads the necessary data.