### PR TITLE
Reinstate macOS builds (with incorrect labels).

### DIFF
--- a/etc/scipipe/build_matrix.yaml
+++ b/etc/scipipe/build_matrix.yaml
@@ -73,6 +73,20 @@ template:
       label: osx-10.14
       compiler: conda-system
       python: '3'
+    - &catalina-conda
+      <<: *platform_defaults
+      image: null
+      # Yes, the label is inconsistent for historical reasons
+      label: osx-10.13
+      compiler: conda-system
+      python: '3'
+    - &bigsur-conda
+      <<: *platform_defaults
+      image: null
+      # Yes, the label is inconsistent for historical reasons
+      label: osx-10.14
+      compiler: conda-system
+      python: '3'
 #
 # build environment/matrix configs
 #
@@ -81,20 +95,20 @@ scipipe-lsstsw-matrix:
 #    allow_fail: true
   - <<: *el8-conda
 #    allow_fail: true
-#  - <<: *high_sierra-conda
-    # allow builds on sierra and mojave
-#    label: osx-10.13||osx-10.14
-#    display_name: osx
-#    display_compiler: clang
+  - <<: *catalina-conda
+    # allow builds on catalina and big sur
+    label: osx-10.13||osx-10.14
+    display_name: osx
+    display_compiler: clang
 scipipe-lsstsw-lsst_distrib:
   - <<: *el7-conda
   - <<: *el8-conda
-#  - <<: *high_sierra-conda
-#  - <<: *mojave-conda
+  - <<: *catalina-conda
+  - <<: *bigsur-conda
 scipipe-lsstsw-ci_hsc:
   - <<: *el7-conda
   - <<: *el8-conda
-#  - <<: *mojave-conda
+  - <<: *bigsur-conda
 dax-lsstsw-matrix:
   - <<: *el7-conda
     splenv_ref: 'ceb6bb6'
@@ -128,12 +142,12 @@ tarball:
       <<: *el7-conda
       platform: el7
       osfamily: redhat
-#    - <<: *tarball_defaults
-#      <<: *mojave-conda
-#      platform: '10.9'
-#      osfamily: osx
-#      timelimit: 8
-#      allow_fail: true
+    - <<: *tarball_defaults
+      <<: *bigsur-conda
+      platform: '10.9'
+      osfamily: osx
+      timelimit: 8
+      allow_fail: true
 #
 # X-release pattern pipelines
 #


### PR DESCRIPTION
The agent labels are still 10.13 and 10.14 rather than 10.15 and 11.0.