### PR TITLE
Added parameters to deploy a pre-released rubinenv-feedstock

### DIFF
--- a/jobs/stack_os_matrix_test.groovy
+++ b/jobs/stack_os_matrix_test.groovy
@@ -12,8 +12,8 @@ p.pipeline().with {
     stringParam('PRODUCTS', scipipe.canonical.products,
       'Whitespace delimited list of EUPS products to build.')
     stringParam('SPLENV_REF', scipipe.template.splenv_ref, 'conda env ref')
-    // XXX testing only
-    //booleanParam('NO_FETCH', false, 'Do not pull from git remote if branch is already the current ref. (This should generally be false outside of testing the CI system)')
+    stringParam('RUBINENV_ORG_FORK', null, 'Organization where to look for rubinenv-feedstock fork.')
+    stringParam('RUBINENV_BRANCH', null, 'Branch to test in the rubinenv-feedstock fork.')
   }
 
   concurrentBuild(true)

--- a/pipelines/stack_os_matrix_test.groovy
+++ b/pipelines/stack_os_matrix_test.groovy
@@ -33,19 +33,12 @@ notify.wrap {
     LSST_SPLENV_REF: SPLENV_REF
   ]
 
-  // override conda env ref from build_matrix.yaml
-  //if (params.SPLENV_REF) {
-  //  buildParams['LSST_SPLENV_REF'] = params.SPLENV_REF
-  //}
-  // To remove (since SPLENV_REF is set by default)
-  //  and added in the def buildParams just above
-
   // if provided fork parameters, add them to the build params
   if (params.RUBINENV_ORG_FORK != null) {
-    buildParams['RUBINENV_ORG_FORK']=params.RUBINENV_ORG_FORK
+    buildParams['RUBINENV_ORG_FORK'] = params.RUBINENV_ORG_FORK
   }
   if (params.RUBINENV_BRANCHi != null) {
-    buildParams['RUBINENV_BRANCH']=params.RUBINENV_BRANCH
+    buildParams['RUBINENV_BRANCH'] = params.RUBINENV_BRANCH
   }
 
   def lsstswConfigs = scipipe[BUILD_CONFIG]

--- a/pipelines/stack_os_matrix_test.groovy
+++ b/pipelines/stack_os_matrix_test.groovy
@@ -30,11 +30,22 @@ notify.wrap {
     LSST_REFS:      REFS,
     LSST_PRODUCTS:  PRODUCTS,
     LSST_BUILD_DOCS: BUILD_DOCS,
+    LSST_SPLENV_REF: SPLENV_REF
   ]
 
   // override conda env ref from build_matrix.yaml
-  if (params.SPLENV_REF) {
-    buildParams['LSST_SPLENV_REF'] = params.SPLENV_REF
+  //if (params.SPLENV_REF) {
+  //  buildParams['LSST_SPLENV_REF'] = params.SPLENV_REF
+  //}
+  // To remove (since SPLENV_REF is set by default)
+  //  and added in the def buildParams just above
+
+  // if provided fork parameters, add them to the build params
+  if (params.RUBINENV_ORG_FORK != null) {
+    buildParams['RUBINENV_ORG_FORK']=params.RUBINENV_ORG_FORK
+  }
+  if (params.RUBINENV_BRANCHi != null) {
+    buildParams['RUBINENV_BRANCH']=params.RUBINENV_BRANCH
   }
 
   def lsstswConfigs = scipipe[BUILD_CONFIG]


### PR DESCRIPTION
I have updated the exiting stack-os-matrix-test. This requires an additional change in ci-scripts (DM-27005 branch) in order to work.