### PR TITLE
[DM-27809] Test validate_drp, validate_drp_gen3 and ap_verify pipelines with the squash-sandbox instance

### DIFF
--- a/etc/sqre/config.yaml
+++ b/etc/sqre/config.yaml
@@ -51,7 +51,7 @@ wget:
     tag: latest
 squash:
   url: https://squash-restful-api.lsst.codes/
-  sandbox_url: https://squash-restful-api-sandbox.lsst.codes
+  sandbox_url: https://squash-sandbox.lsst.codes/
 scipipe_base:
   docker_registry:
     repo: lsstdm/scipipe-base

--- a/pipelines/scipipe/ap_verify.groovy
+++ b/pipelines/scipipe/ap_verify.groovy
@@ -288,6 +288,13 @@ def void verifyDataset(Map p) {
                   resultFile: f,
                   squashUrl: sqre.squash.url,
                 )
+                util.runDispatchVerify(
+                  runDir: runDir,
+                  lsstswDir: fakeLsstswDir,
+                  datasetName: ds.name,
+                  resultFile: f,
+                  squashUrl: sqre.squash.sandbox_url,
+                )
               }
             }
             break

--- a/pipelines/sqre/validate_drp.groovy
+++ b/pipelines/sqre/validate_drp.groovy
@@ -264,6 +264,13 @@ def void verifyDataset(Map p) {
             resultFile: f,
             squashUrl: sqre.squash.url,
           )
+          util.runDispatchVerify(
+            runDir: runDir,
+            lsstswDir: fakeLsstswDir,
+            datasetName: ds.name,
+            resultFile: f,
+            squashUrl: sqre.squash.sandbox_url,
+          )
         }
       }
     } // inside

--- a/pipelines/sqre/validate_drp_gen3.groovy
+++ b/pipelines/sqre/validate_drp_gen3.groovy
@@ -251,6 +251,13 @@ def void verifyDataset(Map p) {
             resultFile: f,
             squashUrl: sqre.squash.url,
           )
+          util.runDispatchVerify(
+            runDir: runDir,
+            lsstswDir: fakeLsstswDir,
+            datasetName: ds.name,
+            resultFile: f,
+            squashUrl: sqre.squash.sandbox_url,
+          )
         }
       }
     } // inside
@@ -314,7 +321,7 @@ def void buildDrpGen3(Map p) {
 
       source /opt/lsst/software/stack/loadLSST.bash
       setup -k -r .
-      
+
       pip install --user dustmaps
       python -c "import dustmaps.sfd;dustmaps.sfd.fetch()"
 


### PR DESCRIPTION
- Repeat the dispatch verify step sending verification jobs for the validate_drp, validate_drp_gen3 and ap_verify pipelines to to the SQuaSH Sandbox instance, in addition to the current production instance.  We want both running together for some time to make sure it works before switching over to a new production instance.