### PR TITLE
Introducing rubin-env

### DIFF
--- a/etc/scipipe/build_matrix.yaml
+++ b/etc/scipipe/build_matrix.yaml
@@ -5,7 +5,7 @@
 # provide yaml anchors internal to this file.
 #
 template:
-  splenv_ref: &splenv_ref 'cb4e2dc'
+  splenv_ref: &splenv_ref '0.1.4'
   tarball_defaults: &tarball_defaults
     miniver: &miniver 'py37_4.8.2'
     timelimit: 6

--- a/etc/scipipe/build_matrix.yaml
+++ b/etc/scipipe/build_matrix.yaml
@@ -5,9 +5,9 @@
 # provide yaml anchors internal to this file.
 #
 template:
-  splenv_ref: &splenv_ref '0.1.4'
+  splenv_ref: &splenv_ref '0.1.5'
   tarball_defaults: &tarball_defaults
-    miniver: &miniver 'py37_4.8.2'
+    miniver: &miniver 'py38_4.9.2'
     timelimit: 6
   linux_compiler: &linux_compiler devtoolset-6
   platform_defaults: &platform_defaults

--- a/pipelines/release/tarball.groovy
+++ b/pipelines/release/tarball.groovy
@@ -728,6 +728,10 @@ def String buildScript(
       eups distrib create --server-dir "\$EUPS_PKGROOT" -d tarball "\$prod" -t "${tag}" -vvv
     done
     eups distrib declare --server-dir "\$EUPS_PKGROOT" -t "${tag}" -vvv
+
+    # saving environment information
+    mkdir -p "\${EUPS_PKGROOT}/env"
+    conda list --explicit > "\${EUPS_PKGROOT}/env/${tag}.env"
   """)
 }
 


### PR DESCRIPTION
Changed from the scipipe-conda-env SHA1 to the rubin-env version.

Changed miniconda from version py37.4.8.2 to version py38.4.9.2.

Record of the pinned environment (conda list --explicit) for future use in case of debugging or environment re-creation.