### PR TITLE
Revert change to dispatch jobs to squash sandbox

### DIFF
--- a/etc/sqre/config.yaml
+++ b/etc/sqre/config.yaml
@@ -51,7 +51,7 @@ wget:
     tag: latest
 squash:
   url: https://squash-restful-api.lsst.codes/
-  sandbox_url: https://squash-sandbox.lsst.codes/
+  sandbox_url: https://squash-restful-api-sandbox.lsst.codes
 scipipe_base:
   docker_registry:
     repo: lsstdm/scipipe-base

--- a/pipelines/scipipe/ap_verify.groovy
+++ b/pipelines/scipipe/ap_verify.groovy
@@ -288,13 +288,6 @@ def void verifyDataset(Map p) {
                   resultFile: f,
                   squashUrl: sqre.squash.url,
                 )
-                util.runDispatchVerify(
-                  runDir: runDir,
-                  lsstswDir: fakeLsstswDir,
-                  datasetName: ds.name,
-                  resultFile: f,
-                  squashUrl: sqre.squash.sandbox_url,
-                )
               }
             }
             break

--- a/pipelines/sqre/validate_drp.groovy
+++ b/pipelines/sqre/validate_drp.groovy
@@ -264,13 +264,6 @@ def void verifyDataset(Map p) {
             resultFile: f,
             squashUrl: sqre.squash.url,
           )
-          util.runDispatchVerify(
-            runDir: runDir,
-            lsstswDir: fakeLsstswDir,
-            datasetName: ds.name,
-            resultFile: f,
-            squashUrl: sqre.squash.sandbox_url,
-          )
         }
       }
     } // inside

--- a/pipelines/sqre/validate_drp_gen3.groovy
+++ b/pipelines/sqre/validate_drp_gen3.groovy
@@ -251,13 +251,6 @@ def void verifyDataset(Map p) {
             resultFile: f,
             squashUrl: sqre.squash.url,
           )
-          util.runDispatchVerify(
-            runDir: runDir,
-            lsstswDir: fakeLsstswDir,
-            datasetName: ds.name,
-            resultFile: f,
-            squashUrl: sqre.squash.sandbox_url,
-          )
         }
       }
     } // inside
@@ -321,7 +314,7 @@ def void buildDrpGen3(Map p) {
 
       source /opt/lsst/software/stack/loadLSST.bash
       setup -k -r .
-
+      
       pip install --user dustmaps
       python -c "import dustmaps.sfd;dustmaps.sfd.fetch()"
 


### PR DESCRIPTION
- There's a collision of endpoint names between the squash and the gafaelfawr API's both have `/auth` and I didn't antecipate that. The solution is probably add a subpath for the squash api, but this change is not that easy.  