### PR TITLE
DM-28888: Allow SQuaSH uploads from ap_verify Gen 3

### DIFF
--- a/pipelines/lib/util.groovy
+++ b/pipelines/lib/util.groovy
@@ -1995,6 +1995,73 @@ def void runDispatchVerify(Map p) {
 } // runDispatchVerify
 
 /**
+ * Convert Gen 3 results into a form suitable for dispatch-verify.
+ *
+ * Example:
+ *
+ *     util.runGen3ToJob(
+ *       gen3Dir: gen3Dir,
+ *       collectionName: collectionName,
+ *       namespace: "",
+ *       datasetName: datasetName,
+ *     )
+ *
+ * @param p Map
+ * @param p.gen3Dir String Path to the Gen 3 repository
+ * @param p.collectionName String The collection to search for metrics.
+ * @param p.namespace String The metrics namespace to filter by, e.g. validate_drp, or "" for all metrics.
+ * @param p.datasetName String The dataset name. Eg., validation_data_cfht
+ */
+def void runGen3ToJob(Map p) {
+  util.requireMapKeys(p, [
+    'gen3Dir',
+    'collectionName',
+    'namespace',
+    'datasetName',
+  ])
+
+  def run = {
+    util.bash '''
+      set +o xtrace
+      source /opt/lsst/software/stack/loadLSST.bash
+      setup verify
+      set -o xtrace
+
+      if [[ -n $METRIC_NAMESPACE ]]
+        then gen3_to_job.py \
+          "$REPO_DIR" \
+          "$OUTPUT_COLLECTION" \
+          --metrics_package "$METRIC_NAMESPACE" \
+          --dataset_name "$dataset"
+        else gen3_to_job.py \
+          "$REPO_DIR" \
+          "$OUTPUT_COLLECTION" \
+          --dataset_name "$dataset"
+      fi
+    '''
+  } // run
+
+  /*
+  These are already present under pipeline:
+  - BUILD_ID
+  - BUILD_URL
+
+  This var was defined automagically by matrixJob and now must be manually
+  set:
+  - dataset
+  */
+  withEnv([
+    "REPO_DIR=${p.gen3Dir}",
+    "OUTPUT_COLLECTION=${p.collectionName}",
+    "METRIC_NAMESPACE=${p.namespace}",
+    "dataset=${p.datasetName}",
+  ]) {
+    // Don't change directories to avoid cluttering repo with external files
+    run()
+  } // withEnv
+} // runGen3ToJob
+
+/**
  * Create a "fake" lsstsw-ish dir structure as expected by
  * `dispatch-verify.py`, which includes a `manifest.txt` and a copy of
  * `repos.yaml`.

--- a/pipelines/lib/util_test.groovy
+++ b/pipelines/lib/util_test.groovy
@@ -1995,6 +1995,73 @@ def void runDispatchVerify(Map p) {
 } // runDispatchVerify
 
 /**
+ * Convert Gen 3 results into a form suitable for dispatch-verify.
+ *
+ * Example:
+ *
+ *     util.runGen3ToJob(
+ *       gen3Dir: gen3Dir,
+ *       collectionName: collectionName,
+ *       namespace: "",
+ *       datasetName: datasetName,
+ *     )
+ *
+ * @param p Map
+ * @param p.gen3Dir String Path to the Gen 3 repository
+ * @param p.collectionName String The collection to search for metrics.
+ * @param p.namespace String The metrics namespace to filter by, e.g. validate_drp, or "" for all metrics.
+ * @param p.datasetName String The dataset name. Eg., validation_data_cfht
+ */
+def void runGen3ToJob(Map p) {
+  util.requireMapKeys(p, [
+    'gen3Dir',
+    'collectionName',
+    'namespace',
+    'datasetName',
+  ])
+
+  def run = {
+    util.bash '''
+      set +o xtrace
+      source /opt/lsst/software/stack/loadLSST.bash
+      setup verify
+      set -o xtrace
+
+      if [[ -n $METRIC_NAMESPACE ]]
+        then gen3_to_job.py \
+          "$REPO_DIR" \
+          "$OUTPUT_COLLECTION" \
+          --metrics_package "$METRIC_NAMESPACE" \
+          --dataset_name "$dataset"
+        else gen3_to_job.py \
+          "$REPO_DIR" \
+          "$OUTPUT_COLLECTION" \
+          --dataset_name "$dataset"
+      fi
+    '''
+  } // run
+
+  /*
+  These are already present under pipeline:
+  - BUILD_ID
+  - BUILD_URL
+
+  This var was defined automagically by matrixJob and now must be manually
+  set:
+  - dataset
+  */
+  withEnv([
+    "REPO_DIR=${p.gen3Dir}",
+    "OUTPUT_COLLECTION=${p.collectionName}",
+    "METRIC_NAMESPACE=${p.namespace}",
+    "dataset=${p.datasetName}",
+  ]) {
+    // Don't change directories to avoid cluttering repo with external files
+    run()
+  } // withEnv
+} // runGen3ToJob
+
+/**
  * Create a "fake" lsstsw-ish dir structure as expected by
  * `dispatch-verify.py`, which includes a `manifest.txt` and a copy of
  * `repos.yaml`.

--- a/pipelines/scipipe/ap_verify.groovy
+++ b/pipelines/scipipe/ap_verify.groovy
@@ -271,8 +271,15 @@ def void verifyDataset(Map p) {
       if (p.squashPush) {
         switch (conf.gen) {
           case 3:
-            // TODO: implement after DM-21916
-            break  // Avoid fall-through until Gen 3 code ready
+            // Partially hard-coded in ap_verify
+            def gen3Dir = util.joinPath(runDir, ds.name, "repo")
+            def collection = "ap_verify-output"
+            util.runGen3ToJob(
+              gen3Dir: gen3Dir,
+              collectionName: collection,
+              namespace: "",
+              datasetName: ds.name,
+            )
             // Delegate upload to Gen 2 code
           case 2:
             def files = []

--- a/pipelines/scipipe/ap_verify.groovy
+++ b/pipelines/scipipe/ap_verify.groovy
@@ -270,10 +270,14 @@ def void verifyDataset(Map p) {
       // push results to squash
       if (p.squashPush) {
         switch (conf.gen) {
+          case 3:
+            // TODO: implement after DM-21916
+            break  // Avoid fall-through until Gen 3 code ready
+            // Delegate upload to Gen 2 code
           case 2:
             def files = []
             dir(runDir) {
-              files = findFiles(glob: '**/ap_verify.*.verify.json')
+              files = findFiles(glob: '**/*.verify.json')
             }
 
             def codeRef = buildCode ? code.git_ref : "master"
@@ -290,9 +294,6 @@ def void verifyDataset(Map p) {
                 )
               }
             }
-            break
-          case 3:
-            // TODO: implement after DM-21916
             break
           default:
             currentBuild.result = 'UNSTABLE'


### PR DESCRIPTION
This PR updates the `scipipe/ap_verify` job to upload metrics from Gen 3 `ap_verify` runs to SQuaSH. It also adds a utility that would allow other pipelines to use the same scripts.