### PR TITLE
DM-29004: Gen 3 SQuaSH upload fails in ap_verify job

### DIFF
--- a/pipelines/scipipe/ap_verify.groovy
+++ b/pipelines/scipipe/ap_verify.groovy
@@ -272,9 +272,15 @@ def void verifyDataset(Map p) {
         switch (conf.gen) {
           case 3:
             // Partially hard-coded in ap_verify
-            def gen3Dir = util.joinPath(runDir.toString(), ds.name.toString(), 'repo')
+            def gen3Dir = util.joinPath(runDir, ds.name, 'repo')
+            def collection = 'ap_verify-output'
+            util.runGen3ToJob(
+              gen3Dir: gen3Dir,
+              collectionName: collection,
+              namespace: '',
+              datasetName: ds.name,
+            )
             // Delegate upload to Gen 2 code
-            break
           case 2:
             def files = []
             dir(runDir) {

--- a/pipelines/scipipe/ap_verify.groovy
+++ b/pipelines/scipipe/ap_verify.groovy
@@ -271,8 +271,9 @@ def void verifyDataset(Map p) {
       if (p.squashPush) {
         switch (conf.gen) {
           case 3:
-            // Partially hard-coded in ap_verify
-            def gen3Dir = util.joinPath(runDir, ds.name, 'repo')
+            // Path is partially hard-coded in ap_verify.
+            // runDir is a GString, which doesn't get auto-converted in this case.
+            def gen3Dir = util.joinPath(runDir.toString(), ds.name, 'repo')
             def collection = 'ap_verify-output'
             util.runGen3ToJob(
               gen3Dir: gen3Dir,


### PR DESCRIPTION
This PR reverts the various experimental changes merged to `master` (squashed into a single commit), and then fixes Jenkins's inability to call `util.joinPath`.

This PR does not include f4b5babaaf76d9e7d19f73d0940e0e8b54f70a40, which was already merged to `master`, but which should be considered a permanent change made as part of DM-29004.