### PR TITLE
DM-29066: gen3_to_job.py does not create uploadable Jobs

### DIFF
--- a/pipelines/lib/util.groovy
+++ b/pipelines/lib/util.groovy
@@ -1997,9 +1997,12 @@ def void runDispatchVerify(Map p) {
 /**
  * Convert Gen 3 results into a form suitable for dispatch-verify.
  *
+ * The output files are placed in runDir.
+ *
  * Example:
  *
  *     util.runGen3ToJob(
+ *       runDir: runDir,
  *       gen3Dir: gen3Dir,
  *       collectionName: collectionName,
  *       namespace: "",
@@ -2007,6 +2010,7 @@ def void runDispatchVerify(Map p) {
  *     )
  *
  * @param p Map
+ * @param p.runDir String
  * @param p.gen3Dir String Path to the Gen 3 repository
  * @param p.collectionName String The collection to search for metrics.
  * @param p.namespace String The metrics namespace to filter by, e.g. validate_drp, or "" for all metrics.
@@ -2056,8 +2060,9 @@ def void runGen3ToJob(Map p) {
     "METRIC_NAMESPACE=${p.namespace}",
     "dataset=${p.datasetName}",
   ]) {
-    // Don't change directories to avoid cluttering repo with external files
-    run()
+    dir(p.runDir) {
+      run()
+    }
   } // withEnv
 } // runGen3ToJob
 

--- a/pipelines/lib/util_test.groovy
+++ b/pipelines/lib/util_test.groovy
@@ -1997,9 +1997,12 @@ def void runDispatchVerify(Map p) {
 /**
  * Convert Gen 3 results into a form suitable for dispatch-verify.
  *
+ * The output files are placed in runDir.
+ *
  * Example:
  *
  *     util.runGen3ToJob(
+ *       runDir: runDir,
  *       gen3Dir: gen3Dir,
  *       collectionName: collectionName,
  *       namespace: "",
@@ -2007,6 +2010,7 @@ def void runDispatchVerify(Map p) {
  *     )
  *
  * @param p Map
+ * @param p.runDir String
  * @param p.gen3Dir String Path to the Gen 3 repository
  * @param p.collectionName String The collection to search for metrics.
  * @param p.namespace String The metrics namespace to filter by, e.g. validate_drp, or "" for all metrics.
@@ -2056,8 +2060,9 @@ def void runGen3ToJob(Map p) {
     "METRIC_NAMESPACE=${p.namespace}",
     "dataset=${p.datasetName}",
   ]) {
-    // Don't change directories to avoid cluttering repo with external files
-    run()
+    dir(p.runDir) {
+      run()
+    }
   } // withEnv
 } // runGen3ToJob
 

--- a/pipelines/scipipe/ap_verify.groovy
+++ b/pipelines/scipipe/ap_verify.groovy
@@ -272,10 +272,10 @@ def void verifyDataset(Map p) {
         switch (conf.gen) {
           case 3:
             // Path is partially hard-coded in ap_verify.
-            // runDir is a GString, which doesn't get auto-converted in this case.
-            def gen3Dir = util.joinPath(runDir.toString(), ds.name, 'repo')
+            def gen3Dir = util.joinPath(ds.name, 'repo')
             def collection = 'ap_verify-output'
             util.runGen3ToJob(
+              runDir: runDir,
               gen3Dir: gen3Dir,
               collectionName: collection,
               namespace: '',


### PR DESCRIPTION
This PR fixes an error in gen3ToJob that always ran the script from the Jenkins base directory instead of the run directory. This prevented its output files from being uploaded to SQuaSH, and would have allowed concurrent Gen 3 jobs to overwrite each others' outputs.