### PR TITLE
DM-29041: Support repository names as ap_verify --dataset argument and deprecate old names

### DIFF
--- a/etc/scipipe/ap_verify.yaml
+++ b/etc/scipipe/ap_verify.yaml
@@ -9,13 +9,13 @@ template:
   datasets:
     hits2015: &dataset_hits2015
       display_name: hits2015
-      name: CI-HiTS2015
+      name: ap_verify_ci_hits2015
       github_repo: lsst/ap_verify_ci_hits2015
       git_ref: master
       clone_timelimit: 15
     cosmos_pdr2: &dataset_cosmos_pdr2
       display_name: cosmos_pdr2
-      name: CI-CosmosPDR2
+      name: ap_verify_ci_cosmos_pdr2
       github_repo: lsst/ap_verify_ci_cosmos_pdr2
       git_ref: master
       clone_timelimit: 15


### PR DESCRIPTION
This PR replaces the special `ap_verify` dataset name with the repository name. The two most important uses of this name are as the `--dataset` argument to `ap_verify.py` (supported in lsst/ap_verify#122) and as the dataset identifier (`ci_dataset`) in SQuaSH uploads.