### PR TITLE
DM-21888: Stand up Gen3 version of ap_verify HiTS (2015) CI test

### DIFF
--- a/etc/scipipe/ap_verify.yaml
+++ b/etc/scipipe/ap_verify.yaml
@@ -42,6 +42,11 @@ ap_verify:
       code:
         <<: *code_ap
     - dataset:
+        <<: *dataset_hits2015
+      gen: 3
+      code:
+        <<: *code_ap
+    - dataset:
         <<: *dataset_cosmos_pdr2
       gen: 3
       code:


### PR DESCRIPTION
This PR adds Gen 3 runs of the existing `ap_verify_ci_hits2015` dataset.