### PR TITLE
DM-29341: Enable running Fakes in CI for ap_verify

### DIFF
--- a/etc/scipipe/ap_verify.yaml
+++ b/etc/scipipe/ap_verify.yaml
@@ -11,12 +11,14 @@ template:
       display_name: hits2015
       name: ap_verify_ci_hits2015
       github_repo: lsst/ap_verify_ci_hits2015
+      gen3_pipeline: ${AP_VERIFY_DIR}/pipelines/ApVerifyWithFakes.yaml
       git_ref: master
       clone_timelimit: 15
     cosmos_pdr2: &dataset_cosmos_pdr2
       display_name: cosmos_pdr2
       name: ap_verify_ci_cosmos_pdr2
       github_repo: lsst/ap_verify_ci_cosmos_pdr2
+      gen3_pipeline: ${AP_VERIFY_DIR}/pipelines/ApVerifyWithFakes.yaml
       git_ref: master
       clone_timelimit: 15
   codes:

--- a/pipelines/scipipe/ap_verify.groovy
+++ b/pipelines/scipipe/ap_verify.groovy
@@ -261,6 +261,7 @@ def void verifyDataset(Map p) {
         runDir: runDir,
         dataset: ds,
         gen: conf.gen,
+        pipeline: conf.pipeline,
         datasetDir: datasetDir,
         homeDir: homeDir,
         archiveDir: jobDir,
@@ -405,6 +406,7 @@ def void runApVerify(Map p) {
     'runDir',
     'dataset',
     'gen',
+    'pipeline',
     'datasetDir',
     'homeDir',
     'archiveDir',
@@ -427,7 +429,8 @@ def void runApVerify(Map p) {
       setup -k -r .
 
       cd ${RUN_DIR}
-      run_ci_dataset.sh -d ${DATASET_NAME} -g ${DATASET_GEN}
+      # -p ignored if not -g 3
+      run_ci_dataset.sh -d ${DATASET_NAME} -g ${DATASET_GEN} -p ${DATASET_PIPE}
     '''
   }
 
@@ -436,6 +439,7 @@ def void runApVerify(Map p) {
     "RUN_DIR=${p.runDir}",
     "DATASET_NAME=${p.dataset.name}",
     "DATASET_GEN=${p.gen}",
+    "DATASET_PIPE"=${p.pipeline}
     "DATASET_DIR=${p.datasetDir}",
     "HOME=${p.homeDir}",
     "CODE_DIR=${p.codeDir}",


### PR DESCRIPTION
This PR adds dataset-specific pipelines (currently the central defaults in `ap_verify`) to the CI configuration and passes them to the flag introduced in lsst/ap_verify#128. This hopefully provides forward-compatibility with RFC-775, but an immediate application is running fakes on all datasets in Gen 3.