### PR TITLE
DM-29341: Enable running Fakes in CI for ap_verify (take 5)

### DIFF
--- a/etc/scipipe/ap_verify.yaml
+++ b/etc/scipipe/ap_verify.yaml
@@ -11,7 +11,7 @@ template:
       display_name: hits2015
       name: ap_verify_ci_hits2015
       github_repo: lsst/ap_verify_ci_hits2015
-      gen3_pipeline: ${AP_VERIFY_DIR}/pipelines/ApVerifyWithFakes.yaml
+      gen3_pipeline: ${AP_VERIFY_DIR}/pipelines/ApVerify.yaml
       git_ref: master
       clone_timelimit: 15
     cosmos_pdr2: &dataset_cosmos_pdr2


### PR DESCRIPTION
This PR runs the Fakes pipeline only on the HSC dataset, and not the HiTS dataset. HiTS support may be added later.