### PR TITLE
DM-30349: Run ApVerifyWithFakes on HiTS

### DIFF
--- a/etc/scipipe/ap_verify.yaml
+++ b/etc/scipipe/ap_verify.yaml
@@ -11,7 +11,7 @@ template:
       display_name: hits2015
       name: ap_verify_ci_hits2015
       github_repo: lsst/ap_verify_ci_hits2015
-      gen3_pipeline: ${AP_VERIFY_DIR}/pipelines/ApVerify.yaml
+      gen3_pipeline: ${AP_VERIFY_DIR}/pipelines/ApVerifyWithFakes.yaml
       git_ref: master
       clone_timelimit: 15
     cosmos_pdr2: &dataset_cosmos_pdr2


### PR DESCRIPTION
This PR runs the fakes pipeline on HiTS data, which has been supported for a while.