### PR TITLE
Increase tarball timeout to 8 hours.

### DIFF
--- a/etc/scipipe/build_matrix.yaml
+++ b/etc/scipipe/build_matrix.yaml
@@ -8,7 +8,7 @@ template:
   splenv_ref: &splenv_ref '0.7.0'
   tarball_defaults: &tarball_defaults
     miniver: &miniver 'py38_4.9.2'
-    timelimit: 6
+    timelimit: 8
   linux_compiler: &linux_compiler devtoolset-6
   platform_defaults: &platform_defaults
     splenv_ref: *splenv_ref


### PR DESCRIPTION
Recent jobs have been taking more than 6 hours.  Increase this temporarily until a better solution can be found.