### PR TITLE
DM-33150: Remove Gen 2 ap_verify runs

### DIFF
--- a/etc/scipipe/ap_verify.yaml
+++ b/etc/scipipe/ap_verify.yaml
@@ -37,16 +37,6 @@ ap_verify:
   configs:
     - dataset:
         <<: *dataset_hits2015
-      gen: 2
-      code:
-        <<: *code_ap
-    - dataset:
-        <<: *dataset_cosmos_pdr2
-      gen: 2
-      code:
-        <<: *code_ap
-    - dataset:
-        <<: *dataset_hits2015
       gen: 3
       code:
         <<: *code_ap

--- a/pipelines/scipipe/ap_verify.groovy
+++ b/pipelines/scipipe/ap_verify.groovy
@@ -281,8 +281,6 @@ def void verifyDataset(Map p) {
               namespace: '',
               datasetName: ds.name,
             )
-            // Delegate upload to Gen 2 code
-          case 2:
             def files = []
             dir(runDir) {
               files = findFiles(glob: '**/*.verify.json')


### PR DESCRIPTION
This PR removes the Gen 2 `ap_verify` jobs from the Jenkins configuration. The code for managing different generations is kept in place, in case it comes in handy later. In particular, the SQuaSH upload code is essentially still Gen 2.