### PR TITLE
DM-33247: Build and push to Google Artifact Registry.

### DIFF
--- a/pipelines/release/docker/build_stack.groovy
+++ b/pipelines/release/docker/build_stack.groovy
@@ -96,6 +96,7 @@ notify.wrap {
 
       dir(buildDir) {
         image = docker.build("${dockerRepo}", opt.join(' '))
+        image2 = docker.build("panda-dev-1a74/${dockerRepo}", opt.join(' '))
       }
     }
 
@@ -107,6 +108,14 @@ notify.wrap {
         ) {
           registryTags.each { name ->
             image.push(name)
+          }
+        }
+        docker.withRegistry(
+          'https://us-central1-docker.pkg.dev/',
+          'google_archive_registry_sa'
+        ) {
+          registryTags.each { name ->
+            image2.push(name)
           }
         }
       }


### PR DESCRIPTION
The project id must be in the image name for the Jenkins docker push to work correctly, so it seems that we have to build the image twice.