### PR TITLE
Add push to ghcr.io by default as well

### DIFF
--- a/jobs/build_sciplatlab.groovy
+++ b/jobs/build_sciplatlab.groovy
@@ -10,8 +10,8 @@ p.pipeline().with {
   parameters {
     stringParam('TAG', null, 'eups distrib tag')
     stringParam('SUPPLEMENTARY', null, 'Supplementary tag for experimental builds')
-    stringParam('IMAGE', 'docker.io/lsstsqre/sciplat-lab,us-central1-docker.pkg.dev/rubin-shared-services-71ec/sciplat/sciplat-lab', 'Fully-qualified URI(s) for Docker target image(s, comma-separated)')
-    booleanParam('NO_PUSH', false, 'Do not push image to docker registry')
+    stringParam('IMAGE', 'docker.io/lsstsqre/sciplat-lab,us-central1-docker.pkg.dev/rubin-shared-services-71ec/sciplat/sciplat-lab,ghcr.io/lsst-sqre/sciplat-lab', 'Fully-qualified URI(s) for Docker target image(s, comma-separated)')
+    booleanParam('NO_PUSH', false, 'Do not push image to docker registr(y/ies)')
     stringParam('BRANCH', 'prod', 'Branch from which to build image')
   }
 


### PR DESCRIPTION
It might be better to try and do some detection of whether `TAG` starts with `w_` and only add ghcr.io if it does?  But that would also complicate it.