### PR TITLE
Try X instead of V for timezone despite https://docs.oracle.com/javas…

### DIFF
--- a/pipelines/sqre/infra/build_sciplatlab.groovy
+++ b/pipelines/sqre/infra/build_sciplatlab.groovy
@@ -83,7 +83,7 @@ notify.wrap {
       print("starttime: ${starttime}")
       def created_at = starttime.minusSeconds(1)
       // looks like "2022-05-16T22:52:45Z"
-      def fmt=DateTimeFormatter.ofPattern("YYYY-MM-dd'T'HH:mm:ssV")
+      def fmt=DateTimeFormatter.ofPattern("YYYY-MM-dd'T'HH:mm:ssX")
       print("created_at: ${created_at}")
       // One second before we really started the action.
       // Note that we're assuming our local clock and GitHub's are pretty


### PR DESCRIPTION
…e/8/docs/api/java/time/format/DateTimeFormatter.html\#patterns claiming that Z is a legal time-zone ID