### PR TITLE
Remove unwanted JSON artifacts from ap_verify.

### DIFF
--- a/pipelines/scipipe/ap_verify.groovy
+++ b/pipelines/scipipe/ap_verify.groovy
@@ -453,8 +453,7 @@ def void runApVerify(Map p) {
       dir(p.archiveDir) {
         util.record(util.xz([
           "${p.runDir}/**/*.log",
-          "${p.runDir}/**/*.json",  // Gen 2
-          "${p.runDir}/**/metricvalue_*/**/*.yaml",  // Gen 3
+          "${p.runDir}/**/metricvalue_*/**/*.yaml",
           "${p.runDir}/**/*.db",
         ]))
       }


### PR DESCRIPTION
These were Gen2 Middleware data products and task logs that also show up in the `apVerify.log`.