### PR TITLE
Remove mkdir that caused Jenkins pipeline failure

### DIFF
--- a/pipelines/scipipe/ap_verify.groovy
+++ b/pipelines/scipipe/ap_verify.groovy
@@ -224,7 +224,6 @@ def void verifyDataset(Map p) {
     // TODO: remove the block starting here after DM-38454
     // create a new directory for the rbClassifier_data
     def rbClassifierDataDir = "${jobDir}/rbClassifierData"
-    mkdir(rbClassifierDataDir)
     
     // clone rbClassifier_data
     dir(rbClassifierDataDir) {


### PR DESCRIPTION
Problem-
An mkdir command was added in the ap_verify.groovy file with an intention to create a new directory. However, that led to failures in the Jenkins pipeline run.

Changes-
Removed the mkdir command from the groovy file.