### PR TITLE
DM-39143: Implement script for uploading free metrics to Sasquatch

### DIFF
--- a/etc/sqre/config.yaml
+++ b/etc/sqre/config.yaml
@@ -52,6 +52,8 @@ wget:
 squash:
   url: https://squash-restful-api.lsst.codes/
   sandbox_url: https://squash-restful-api-sandbox.lsst.codes
+sasquatch:
+  url: https://usdf-rsp-dev.slac.stanford.edu/sasquatch-rest-proxy/
 scipipe_base:
   docker_registry:
     repo: lsstdm/scipipe-base

--- a/pipelines/scipipe/ap_verify.groovy
+++ b/pipelines/scipipe/ap_verify.groovy
@@ -295,31 +295,19 @@ def void verifyDataset(Map p) {
             // Path is partially hard-coded in ap_verify.
             def gen3Dir = util.joinPath(ds.name, 'repo')
             def collection = 'ap_verify-output'
-            util.runGen3ToJob(
-              runDir: runDir,
-              gen3Dir: gen3Dir,
-              collectionName: collection,
-              namespace: '',
-              datasetName: ds.name,
-            )
-            def files = []
-            dir(runDir) {
-              files = findFiles(glob: '**/*.verify.json')
-            }
 
             def codeRef = buildCode ? code.git_ref : "main"
             withEnv([
               "refs=${codeRef}",
             ]) {
-              files.each { f ->
-                util.runDispatchVerify(
-                  runDir: runDir,
-                  lsstswDir: fakeLsstswDir,
-                  datasetName: ds.name,
-                  resultFile: f,
-                  squashUrl: sqre.squash.url,
-                )
-              }
+              util.runVerifyToSasquatch(
+                runDir: runDir,
+                gen3Dir: gen3Dir,
+                collectionName: collection,
+                namespace: "lsst.verify.ap",
+                datasetName: ds.name,
+                sasquatchUrl: sqre.sasquatch.url
+              )
             }
             break
           default:


### PR DESCRIPTION
This PR modifies the `scipipe/ap_verify` job to use `verify_to_sasquatch.py`, added on lsst/analysis_tools#113, in place of `dispatch_verify.py`.