### PR TITLE
Hotfix for mambaforge.

### DIFF
--- a/pipelines/release/tarball.groovy
+++ b/pipelines/release/tarball.groovy
@@ -845,6 +845,7 @@ def String scriptPreamble(
 
     # isolate conda config
     export CONDARC="\${PWD}/.condarc"
+    touch "$CONDARC"
 
     if [[ \$(uname -s) == Darwin* ]]; then
       export MACOSX_DEPLOYMENT_TARGET="${macosx_deployment_target}"


### PR DESCRIPTION
mambaforge appears to require that `$CONDARC` exist if it is defined.