### PR TITLE
DM-39412: Add Jenkins build ID to ap_verify Sasquatch metadata

### DIFF
--- a/pipelines/lib/util.groovy
+++ b/pipelines/lib/util.groovy
@@ -2138,7 +2138,8 @@ def void runVerifyToSasquatch(Map p) {
           --url "$SASQUATCH_URL" \
           --namespace "$SASQUATCH_NAMESPACE" \
           --extra "ci_id=$BUILD_ID" \
-          --extra "ci_url=$BUILD_URL"
+          --extra "ci_url=$BUILD_URL" \
+          --extra "ci_name=$JOB_NAME"
     '''
   } // run
 
@@ -2146,6 +2147,7 @@ def void runVerifyToSasquatch(Map p) {
   These are already present under pipeline:
   - BUILD_ID
   - BUILD_URL
+  - JOB_NAME
 
   This var was defined automagically by matrixJob and now must be manually
   set:

--- a/pipelines/lib/util.groovy
+++ b/pipelines/lib/util.groovy
@@ -2136,11 +2136,17 @@ def void runVerifyToSasquatch(Map p) {
           "$OUTPUT_COLLECTION" \
           --dataset "$dataset" \
           --url "$SASQUATCH_URL" \
-          --namespace "$SASQUATCH_NAMESPACE"
+          --namespace "$SASQUATCH_NAMESPACE" \
+          --extra "ci_id=$BUILD_ID" \
+          --extra "ci_url=$BUILD_URL"
     '''
   } // run
 
   /*
+  These are already present under pipeline:
+  - BUILD_ID
+  - BUILD_URL
+
   This var was defined automagically by matrixJob and now must be manually
   set:
   - dataset

--- a/pipelines/lib/util.groovy
+++ b/pipelines/lib/util.groovy
@@ -2104,7 +2104,8 @@ def void runGen3ToJob(Map p) {
  *       collectionName: collectionName,
  *       namespace: "lsst.example",
  *       datasetName: "ci_example",
- *       sasquatchUrl: util.sqreConfig().sasquatch.url
+ *       sasquatchUrl: util.sqreConfig().sasquatch.url,
+ *       branchRefs: "tickets/DM-12345 tickets/DM-67890"
  *     )
  * @param p Map
  * @param p.runDir String
@@ -2113,6 +2114,7 @@ def void runGen3ToJob(Map p) {
  * @param p.namespace String The Sasquatch namespace to push to, e.g., lsst.dm.
  * @param p.datasetName String The dataset name. Eg., validation_data_cfht
  * @param p.sasquatchUrl String The URL to the Sasquatch REST proxy.
+ * @param p.branchRefs String The branch(es) used in the run, as a space-delimited string (optional).
  */
 def void runVerifyToSasquatch(Map p) {
   util.requireMapKeys(p, [
@@ -2139,7 +2141,8 @@ def void runVerifyToSasquatch(Map p) {
           --namespace "$SASQUATCH_NAMESPACE" \
           --extra "ci_id=$BUILD_ID" \
           --extra "ci_url=$BUILD_URL" \
-          --extra "ci_name=$JOB_NAME"
+          --extra "ci_name=$JOB_NAME" \
+          --extra "ci_refs=$JOB_REFS"
     '''
   } // run
 
@@ -2159,6 +2162,7 @@ def void runVerifyToSasquatch(Map p) {
     "SASQUATCH_NAMESPACE=${p.namespace}",
     "dataset=${p.datasetName}",
     "SASQUATCH_URL=${p.sasquatchUrl}",
+    "JOB_REFS=${p.containsKey('branchRefs') ? p.branchRefs : ''}",
   ]) {
     // TODO: need Sasquatch authentication eventually; verify_to_sasquatch.py takes a --token arg
     // withCredentials([[

--- a/pipelines/scipipe/ap_verify.groovy
+++ b/pipelines/scipipe/ap_verify.groovy
@@ -297,18 +297,15 @@ def void verifyDataset(Map p) {
             def collection = 'ap_verify-output'
 
             def codeRef = buildCode ? code.git_ref : "main"
-            withEnv([
-              "refs=${codeRef}",
-            ]) {
-              util.runVerifyToSasquatch(
-                runDir: runDir,
-                gen3Dir: gen3Dir,
-                collectionName: collection,
-                namespace: "lsst.verify.ap",
-                datasetName: ds.name,
-                sasquatchUrl: sqre.sasquatch.url
-              )
-            }
+            util.runVerifyToSasquatch(
+              runDir: runDir,
+              gen3Dir: gen3Dir,
+              collectionName: collection,
+              namespace: "lsst.verify.ap",
+              datasetName: ds.name,
+              sasquatchUrl: sqre.sasquatch.url,
+              branchRefs: codeRef
+            )
             break
           default:
             currentBuild.result = 'UNSTABLE'


### PR DESCRIPTION
This PR adds four pieces of metadata [from the old SQuaSH code](https://github.com/lsst/verify/blob/521241d1acd391f78bb7a3be7e40e13cc8356054/python/lsst/verify/metadata/jenkinsci.py) -- `ci_id`, `ci_name`, `ci_url`, and `ci_refs` -- to the Sasquatch upload. All but `ci_refs` are guaranteed to be defined; the last is set to the empty string if it is not present.