### PR TITLE
DM-41985: Fix handling of offline nodes.

### DIFF
--- a/scripts/sqre/infra/jenkins_node_cleanup.groovy
+++ b/scripts/sqre/infra/jenkins_node_cleanup.groovy
@@ -398,8 +398,10 @@ void processNodes() {
       // executors.
       def computer = node.toComputer()
 
-      // a null channel indicates that the node is offline
-      if (computer == null || computer.isOffline()) {
+      if (computer == null) {
+        // a null channel indicates that the node is offline
+        throw new Offline(node)
+      } else if (computer.isOffline()) {
         // check if previous run screwed up
         if (computer.getOfflineCauseReason().startsWith('disk cleanup from job')) {
           // ignore it and clear it at the end


### PR DESCRIPTION
This never used to be a problem, but now that we do have offline nodes due to the "disappearance" issue, it causes cleanup failures.