### PR TITLE
DM-42217: Incorporate ModelPackage Butler datasets into ap_verify

### DIFF
--- a/pipelines/scipipe/ap_verify.groovy
+++ b/pipelines/scipipe/ap_verify.groovy
@@ -221,21 +221,6 @@ def void verifyDataset(Map p) {
       } // timeout
     } // dir
 
-    // TODO: remove the block starting here after DM-38454
-    // create a new directory for the rbClassifier_data
-    def rbClassifierDataDir = "${jobDir}/rbClassifierData"
-    
-    // clone rbClassifier_data
-    dir(rbClassifierDataDir) {
-      timeout(time: ds.clone_timelimit, unit: 'MINUTES') {
-        util.checkoutLFS(
-          githubSlug: 'lsst-dm/rbClassifier_data',
-          gitRef: 'main',
-        )
-      } // timeout
-    } // dir
-    // TODO: remove the block ending here after DM-38454
-
     // clone code
     if (buildCode) {
       dir(codeDir) {
@@ -276,7 +261,7 @@ def void verifyDataset(Map p) {
           archiveDir: jobDir,
         )
       }
-      
+
       runApVerify(
         runDir: runDir,
         dataset: ds,
@@ -285,7 +270,6 @@ def void verifyDataset(Map p) {
         homeDir: homeDir,
         archiveDir: jobDir,
         codeDir: codeDir,
-        rbClassifierDataDir: rbClassifierDataDir, //TODO:remove after DM-38454
       )
 
       // push results to squash
@@ -413,7 +397,6 @@ def void runApVerify(Map p) {
     'homeDir',
     'archiveDir',
     'codeDir',
-    'rbClassifierDataDir' //TODO:remove after DM-38454
   ])
 
   def run = {
@@ -427,9 +410,6 @@ def void runApVerify(Map p) {
       else
         setup ap_verify
       fi
-
-      # TODO: remove the below line after DM-38454 
-      setup -k -r ${RBCLASSIFIER_DATA_DIR}
 
       cd ${DATASET_DIR}
       setup -k -r .
@@ -449,8 +429,6 @@ def void runApVerify(Map p) {
     "DATASET_DIR=${p.datasetDir}",
     "HOME=${p.homeDir}",
     "CODE_DIR=${p.codeDir}",
-    // TODO: remove the below line after DM-38454
-    "RBCLASSIFIER_DATA_DIR=${p.rbClassifierDataDir}",
   ]) {
     try {
       dir(p.runDir) {


### PR DESCRIPTION
This PR reverts downloading of `rbClassifier_data` in `scipipe/ap_verify`. From now on, `ap_verify` data sets will be expected to include a model of their own if they wish to run `rbClassify`.