### PR TITLE
DM-42419: Break up ApVerify into pure with- and without-fakes pipelines

### DIFF
--- a/etc/scipipe/ap_verify.yaml
+++ b/etc/scipipe/ap_verify.yaml
@@ -8,24 +8,24 @@
 template:
   datasets:
     hits2015: &dataset_hits2015
-      display_name: hits2015
-      name: ap_verify_ci_hits2015
+      display_name: hits2015       # Jenkins slug
+      name: ap_verify_ci_hits2015  # ap_verify dataset, Sasquatch dataset ID
       github_repo: lsst/ap_verify_ci_hits2015
       gen3_pipeline: >
         ${AP_VERIFY_CI_HITS2015_DIR}/pipelines/ApVerifyWithFakes.yaml
       git_ref: main
       clone_timelimit: 15
     cosmos_pdr2: &dataset_cosmos_pdr2
-      display_name: cosmos_pdr2
-      name: ap_verify_ci_cosmos_pdr2
+      display_name: cosmos_pdr2       # Jenkins slug
+      name: ap_verify_ci_cosmos_pdr2  # ap_verify dataset, Sasquatch dataset ID
       github_repo: lsst/ap_verify_ci_cosmos_pdr2
       gen3_pipeline: >
         ${AP_VERIFY_CI_COSMOS_PDR2_DIR}/pipelines/ApVerifyWithFakes.yaml
       git_ref: main
       clone_timelimit: 15
     dc2: &dataset_dc2
-      display_name: dc2
-      name: ap_verify_ci_dc2
+      display_name: dc2       # Jenkins slug
+      name: ap_verify_ci_dc2  # ap_verify dataset ID, Sasquatch dataset ID
       github_repo: lsst/ap_verify_ci_dc2
       gen3_pipeline: >
         ${AP_VERIFY_CI_DC2_DIR}/pipelines/ApVerifyWithFakes.yaml

--- a/etc/scipipe/ap_verify.yaml
+++ b/etc/scipipe/ap_verify.yaml
@@ -12,7 +12,7 @@ template:
       name: ap_verify_ci_hits2015  # ap_verify dataset, Sasquatch dataset ID
       github_repo: lsst/ap_verify_ci_hits2015
       gen3_pipeline: >
-        ${AP_VERIFY_CI_HITS2015_DIR}/pipelines/ApVerifyWithFakes.yaml
+        ${AP_VERIFY_CI_HITS2015_DIR}/pipelines/ApVerify.yaml
       git_ref: main
       clone_timelimit: 15
     cosmos_pdr2: &dataset_cosmos_pdr2
@@ -20,7 +20,7 @@ template:
       name: ap_verify_ci_cosmos_pdr2  # ap_verify dataset, Sasquatch dataset ID
       github_repo: lsst/ap_verify_ci_cosmos_pdr2
       gen3_pipeline: >
-        ${AP_VERIFY_CI_COSMOS_PDR2_DIR}/pipelines/ApVerifyWithFakes.yaml
+        ${AP_VERIFY_CI_COSMOS_PDR2_DIR}/pipelines/ApVerify.yaml
       git_ref: main
       clone_timelimit: 15
     dc2: &dataset_dc2
@@ -28,7 +28,7 @@ template:
       name: ap_verify_ci_dc2  # ap_verify dataset ID, Sasquatch dataset ID
       github_repo: lsst/ap_verify_ci_dc2
       gen3_pipeline: >
-        ${AP_VERIFY_CI_DC2_DIR}/pipelines/ApVerifyWithFakes.yaml
+        ${AP_VERIFY_CI_DC2_DIR}/pipelines/ApVerify.yaml
       git_ref: main
       clone_timelimit: 15
   codes:
@@ -55,6 +55,30 @@ ap_verify:
         <<: *code_ap
     - dataset:
         <<: *dataset_dc2
+      gen: 3
+      code:
+        <<: *code_ap
+    - dataset:
+        <<: *dataset_hits2015
+        display_name: hits2015+fakes
+        gen3_pipeline: >
+          ${AP_VERIFY_CI_HITS2015_DIR}/pipelines/ApVerifyWithFakes.yaml
+      gen: 3
+      code:
+        <<: *code_ap
+    - dataset:
+        <<: *dataset_cosmos_pdr2
+        display_name: cosmos_pdr2+fakes
+        gen3_pipeline: >
+          ${AP_VERIFY_CI_COSMOS_PDR2_DIR}/pipelines/ApVerifyWithFakes.yaml
+      gen: 3
+      code:
+        <<: *code_ap
+    - dataset:
+        <<: *dataset_dc2
+        display_name: dc2+fakes
+        gen3_pipeline: >
+          ${AP_VERIFY_CI_DC2_DIR}/pipelines/ApVerifyWithFakes.yaml
       gen: 3
       code:
         <<: *code_ap

--- a/pipelines/lib/util.groovy
+++ b/pipelines/lib/util.groovy
@@ -2106,7 +2106,8 @@ def void runGen3ToJob(Map p) {
  *       namespace: "lsst.example",
  *       datasetName: "ci_example",
  *       sasquatchUrl: util.sqreConfig().sasquatch.url,
- *       branchRefs: "tickets/DM-12345 tickets/DM-67890"
+ *       branchRefs: "tickets/DM-12345 tickets/DM-67890",
+ *       pipeline: "SingleFrame.yaml",
  *     )
  * @param p Map
  * @param p.runDir String
@@ -2116,6 +2117,7 @@ def void runGen3ToJob(Map p) {
  * @param p.datasetName String The dataset name. Eg., validation_data_cfht
  * @param p.sasquatchUrl String The URL to the Sasquatch REST proxy.
  * @param p.branchRefs String The branch(es) used in the run, as a space-delimited string (optional).
+ * @param p.pipeline String The pipeline used in the run (optional).
  */
 def void runVerifyToSasquatch(Map p) {
   util.requireMapKeys(p, [
@@ -2143,7 +2145,8 @@ def void runVerifyToSasquatch(Map p) {
           --extra "ci_id=$BUILD_ID" \
           --extra "ci_url=$BUILD_URL" \
           --extra "ci_name=$JOB_NAME" \
-          --extra "ci_refs=$JOB_REFS"
+          --extra "ci_refs=$JOB_REFS" \
+          --extra "pipeline=$JOB_PIPELINE"
     '''
   } // run
 
@@ -2164,6 +2167,7 @@ def void runVerifyToSasquatch(Map p) {
     "dataset=${p.datasetName}",
     "SASQUATCH_URL=${p.sasquatchUrl}",
     "JOB_REFS=${p.containsKey('branchRefs') ? p.branchRefs : ''}",
+    "JOB_PIPELINE=${p.containsKey('pipeline') ? p.pipeline : ''}",
   ]) {
     // TODO: need Sasquatch authentication eventually; verify_to_sasquatch.py takes a --token arg
     // withCredentials([[

--- a/pipelines/scipipe/ap_verify.groovy
+++ b/pipelines/scipipe/ap_verify.groovy
@@ -293,7 +293,7 @@ def void verifyDataset(Map p) {
             break
           default:
             currentBuild.result = 'UNSTABLE'
-            echo "SQuaSH upload not supported for Gen ${conf.gen} pipeline framework; skipping"
+            echo "Sasquatch upload not supported for Gen ${conf.gen} pipeline framework; skipping"
         }
       }
     } // insideDockerWrap

--- a/pipelines/scipipe/ap_verify.groovy
+++ b/pipelines/scipipe/ap_verify.groovy
@@ -288,7 +288,8 @@ def void verifyDataset(Map p) {
               namespace: "lsst.verify.ap",
               datasetName: ds.name,
               sasquatchUrl: sqre.sasquatch.url,
-              branchRefs: codeRef
+              branchRefs: codeRef,
+              pipeline: new File(ds.gen3_pipeline).getName(),  # equivalent to Python's os.path.basename
             )
             break
           default:

--- a/pipelines/sqre/verify_drp_metrics.groovy
+++ b/pipelines/sqre/verify_drp_metrics.groovy
@@ -251,6 +251,7 @@ def void verifyDataset(Map p) {
         namespace: "lsst.verify.drp",
         datasetName: "HSC/RC2/Nightly",
         sasquatchUrl: sqre.sasquatch.url,
+        pipeline: "DRP-RC2_subset.yaml",
       )
 
       // push results to squash


### PR DESCRIPTION
This PR runs both `ApVerify` and `ApVerifyWithFakes` for each ap_verify dataset, and adds upload metadata to disambiguate the two in Chronograf. This PR must be merged together with lsst/ap_verify#213 to avoid both duplicate metric uploads and missing values.