### PR TITLE
DM-42419 hotfix: Fix broken comment in ap_verify.groovy.

### DIFF
--- a/pipelines/scipipe/ap_verify.groovy
+++ b/pipelines/scipipe/ap_verify.groovy
@@ -289,7 +289,7 @@ def void verifyDataset(Map p) {
               datasetName: ds.name,
               sasquatchUrl: sqre.sasquatch.url,
               branchRefs: codeRef,
-              pipeline: new File(ds.gen3_pipeline).getName(),  # equivalent to Python's os.path.basename
+              pipeline: new File(ds.gen3_pipeline).getName(),  // equivalent to Python's os.path.basename
             )
             break
           default:


### PR DESCRIPTION
A Groovy comment merged in #976 used `#` instead of `//`, which broke the `ap_verify` build.