### PR TITLE
DM-42419 hotfix: Avoid using File class in ap_verify.groovy

### DIFF
--- a/pipelines/scipipe/ap_verify.groovy
+++ b/pipelines/scipipe/ap_verify.groovy
@@ -281,6 +281,7 @@ def void verifyDataset(Map p) {
             def collection = 'ap_verify-output'
 
             def codeRef = buildCode ? code.git_ref : "main"
+            def pipeline_path = ds.gen3_pipeline.split("/")
             util.runVerifyToSasquatch(
               runDir: runDir,
               gen3Dir: gen3Dir,
@@ -289,7 +290,7 @@ def void verifyDataset(Map p) {
               datasetName: ds.name,
               sasquatchUrl: sqre.sasquatch.url,
               branchRefs: codeRef,
-              pipeline: new File(ds.gen3_pipeline).getName(),  // equivalent to Python's os.path.basename
+              pipeline: pipeline_path[pipeline_path.length-1]
             )
             break
           default:


### PR DESCRIPTION
The code merged in #976 used the `File` class to manipulate the path to the pipeline file. This resulted in the following error at run-time:

> Scripts not permitted to use new java.io.File java.lang.String. Administrators can decide whether to approve or reject this signature.