### PR TITLE
DM-42419 hotfix: Fix newlines being included in filenames.

### DIFF
--- a/pipelines/scipipe/ap_verify.groovy
+++ b/pipelines/scipipe/ap_verify.groovy
@@ -291,7 +291,7 @@ def void verifyDataset(Map p) {
               datasetName: ds.name,
               sasquatchUrl: sqre.sasquatch.url,
               branchRefs: codeRef,
-              pipeline: Path.of(ds.gen3_pipeline).getFileName().toString()
+              pipeline: Path.of(ds.gen3_pipeline.trim()).getFileName().toString()
             )
             break
           default:


### PR DESCRIPTION
The YAML config file for `ap_verify` [may contain newlines](https://github.com/lsst-dm/jenkins-dm-jobs/blob/9e948e295deed7c1ae74d2aabec9c70873a4c165/etc/scipipe/ap_verify.yaml#L14-L15) to keep within line length limits. This PR trims these newlines so that they're not passed to `verifyToSasquatch`.