### PR TITLE
DM-25697: Fix official release ap_verify.

### DIFF
--- a/pipelines/release/official_release.groovy
+++ b/pipelines/release/official_release.groovy
@@ -229,7 +229,7 @@ notify.wrap {
           job: 'sqre/verify_drp_metrics',
           parameters: [
             string(name: 'DOCKER_IMAGE', value: stackResults.image),
-            string(name: 'DATASET_REF', value: gitTag),
+            string(name: 'DATASET_REF', value: "refs/tags/" + gitTag),
             booleanParam(
               name: 'NO_PUSH',
               value: scipipe.release.step.verify_drp_metrics.no_push,

--- a/pipelines/release/official_release.groovy
+++ b/pipelines/release/official_release.groovy
@@ -265,7 +265,7 @@ notify.wrap {
           job: 'scipipe/ap_verify',
           parameters: [
             string(name: 'DOCKER_IMAGE', value: stackResults.image),
-            string(name: 'DATASET_REF', value: gitTag),
+            string(name: 'DATASET_REF', value: "refs/tags/" + gitTag),
             booleanParam(
               name: 'NO_PUSH',
               value: scipipe.release.step.ap_verify.no_push,


### PR DESCRIPTION
The tag apparently (not very well documented) needs to be specified as a branch with prefix "refs/tags/".