### PR TITLE
DM-45827-hotfix: Removes extra tag

### DIFF
--- a/etc/scipipe/build_matrix.yaml
+++ b/etc/scipipe/build_matrix.yaml
@@ -139,7 +139,7 @@ newinstall:
     dir: ''
   docker_registry:
     repo: ghcr.io/lsst-dm/docker-newinstall
-    tag: 9-latest-9.0.0
+    tag: 9-latest
   github_repo: lsst/lsst
   git_ref: main
 eups:


### PR DESCRIPTION
DM-45827 fetched  ghcr.io/lsst-dm/docker-newinstall:9-latest-9.0.0-9.0.0, adding an extra 9.0.0. This patch will remove that.