### PR TITLE
DM-46138: Allow jenkins to run on mac minis

### DIFF
--- a/etc/scipipe/build_matrix.yaml
+++ b/etc/scipipe/build_matrix.yaml
@@ -39,11 +39,19 @@ template:
       display_name: macos-13
       compiler: conda-system
       python: '3'
+    - &macarm64-conda
+      <<: *platform_defaults
+      image: null
+      label: mini
+      display_name: macosarm-14
+      compiler: conda-system
+      python: '3'
 #
 # build environment/matrix configs
 #
 scipipe-lsstsw-matrix:
   - <<: *el7-conda
+  - <<: *macarm64-conda
   - <<: *ventura-conda
     # allow builds on monterey and ventura
     label: osx-12||osx-13

--- a/pipelines/lib/util.groovy
+++ b/pipelines/lib/util.groovy
@@ -385,13 +385,12 @@ def lsstswBuild(
       }
   } // runEnv
 
-  def agent = null
+  def agent = lsstswConfig.label
   def task = null
   if (lsstswConfig.image) {
     agent = 'docker'
     task = { runEnv(runDocker) }
   } else {
-    agent = lsstswConfig.label
     task = { runEnv(run) }
   }
 
@@ -1540,7 +1539,7 @@ def String sanitizeEupsTag(String tag) {
   char c = tag.charAt(0)
   if ( c.isDigit() ) {
     tag = "v" + tag
-  } 
+  }
 
   // eups doesn't like dots in tags, convert to underscores
   // by policy, we're not allowing dash either


### PR DESCRIPTION
Allow developers to run mac minis in the stack matrix