### PR TITLE
Add two-python sciplat-lab build to weeklies

### DIFF
--- a/pipelines/release/weekly_release.groovy
+++ b/pipelines/release/weekly_release.groovy
@@ -153,6 +153,21 @@ notify.wrap {
           )
         } // retry
       } // stage
+
+      stage('build two-python Lab images') {
+        retry(retries) {
+          // based on lsstsqre/stack image
+          build(
+            job: 'sqre/infra/build-sciplatlab',
+            parameters: [
+	      string(name: 'BRANCH', value: 'tickets/DM-47346'),
+              string(name: 'TAG', value: eupsTag),
+	      string(name: 'SUPPLEMENTARY', value: '2py'),
+              string(name: 'IMAGE', value: 'docker.io/lsstsqre/sciplat-lab,us-central1-docker.pkg.dev/rubin-shared-services-71ec/sciplat/sciplat-lab,ghcr.io/lsst-sqre/sciplat-lab'),
+            ],
+          )
+        } // retry
+      } // stage
     }
 
     triggerMe['verify_drp_metrics'] = {


### PR DESCRIPTION
This should also build a weekly Lab image based on our sqr-088 (https://sqr-088.lsst.io) two-python work.