### PR TITLE
DM-49043: Move x86 to use alma 9

### DIFF
--- a/etc/scipipe/build_matrix.yaml
+++ b/etc/scipipe/build_matrix.yaml
@@ -15,7 +15,7 @@ template:
   platforms:
     - &el7-conda
       <<: *platform_defaults
-      image: docker.io/lsstdm/scipipe-base:7
+      image: ghcr.io/lsst-dm/docker-scipipe:9-latest
       display_name: linux-9-x86
       label: linux-64
       compiler: conda-system


### PR DESCRIPTION
Tested on https://rubin-ci-dev.slac.stanford.edu/blue/organizations/jenkins/stack-os-matrix/detail/stack-os-matrix/371/pipeline/67