### PR TITLE
Update timelimits in ap_verify.yaml

### DIFF
--- a/etc/scipipe/ap_verify.yaml
+++ b/etc/scipipe/ap_verify.yaml
@@ -41,7 +41,7 @@ ap_verify:
   defaults:
     squash_push: true
     retries: 3
-    run_timelimit: 60
+    run_timelimit: 120
   configs:
     - dataset:
         <<: *dataset_hits2015


### PR DESCRIPTION
Update the timeouts in ap_verify so that the aarch agent doesn't disconnect. 